### PR TITLE
Use bashrc instead of `shell` dependent config file

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ local_bin="$HOME/.local/bin/"
 local_include="$HOME/.local/include/csq"
 csq_bin="$local_bin/csq"
 csq_path="$local_include"
-shell_config="$HOME/.${SHELL##*/}rc"
+shell_config="$HOME/.bashrc"
 
 function install_csq() {
   # Copy csq.py to ~/.local/bin/

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,13 @@ local_bin="$HOME/.local/bin/"
 local_include="$HOME/.local/include/csq"
 csq_bin="$local_bin/csq"
 csq_path="$local_include"
-shell_config="$HOME/.bashrc"
+
+if [ -f "$HOME/.bashrc" ]; then
+    shell_config="$HOME/.bashrc"
+else
+    shell_config="$HOME/.${SHELL##*/}rc"
+fi
+
 
 function install_csq() {
   # Copy csq.py to ~/.local/bin/


### PR DESCRIPTION
Most Linux distro's use `.bashrc` to store most of the config file.
Using the shell dependent config file may create problems where it either doesn't exist and or isn't recognized by the system.