### PR TITLE
OOP for methods

### DIFF
--- a/Compiler/AST/ast.py
+++ b/Compiler/AST/ast.py
@@ -24,6 +24,7 @@ class NodeTypes:
     IMPORT = 15
     UNKNOWN_NODE = 16
     CIMPORT = 17
+    CLASS = 18
 
 
 # Parent AST node type
@@ -244,3 +245,11 @@ class ReturnNode(ASTNode):
         self.type = NodeTypes.RETURN
     def visit(self):
         return "return " + self.value.visit() + ";"
+
+class ClassNode(ASTNode):
+    def __init__(self):
+        super().__init__()
+        self.name = ''
+        self.type = NodeTypes.CLASS
+    def visit(self):
+        return f'__classes__[{self.name}] = Class({self.name});'

--- a/Compiler/AST/ast.py
+++ b/Compiler/AST/ast.py
@@ -253,3 +253,17 @@ class ClassNode(ASTNode):
         self.type = NodeTypes.CLASS
     def visit(self):
         return f'__classes__[{self.name}] = Class({self.name});'
+
+'''
+This class is very much similar to FunDeclNode but this is decl as a method of a class.
+'''
+class MethodNode(ASTNode):
+    def __init__(self):
+        self.identifier = ""
+        self.classname = ''
+        self.parameters = []
+
+    def visit(self):
+        code = f'__classes__["{self.classname}"].methods["{self.identifier}"] = [](Cell& args)' + "{\n"
+
+        return code

--- a/Compiler/AST/ast.py
+++ b/Compiler/AST/ast.py
@@ -252,7 +252,7 @@ class ClassNode(ASTNode):
         self.name = ''
         self.type = NodeTypes.CLASS
     def visit(self):
-        return f'__classes__[{self.name}] = Class({self.name});'
+        return f'__classes__["{self.name}"] = Class();'
 
 '''
 This class is very much similar to FunDeclNode but this is decl as a method of a class.
@@ -264,6 +264,5 @@ class MethodNode(ASTNode):
         self.parameters = []
 
     def visit(self):
-        code = f'__classes__["{self.classname}"].methods["{self.identifier}"] = [](Cell& args)' + "{\n"
-
+        code = f'__classes__["{self.classname}"].methods["{self.identifier}"] = [](Cell args)' + "{\n" + 'allocateVar("arg", "any", args);\n'
         return code

--- a/Compiler/Compiletime/syntax_check.py
+++ b/Compiler/Compiletime/syntax_check.py
@@ -163,3 +163,36 @@ def check_FuncDecl(tokens):
             reason = f"Use of keyword '{token.token}' in function decl."
             break
     return [valid, reason]
+
+def check_IfStmt(tokens):
+    '''
+    This function will be checking the impl of the syntax of if stmt
+    '''
+    valid = True
+    reason = ''
+    if tokens[len(tokens)-1].token != ":":
+        valid = False
+        reason = 'Missing colon at the end in the used if stmt.'
+    return [valid, reason]
+
+def check_ElifStmt(tokens):
+    '''
+    This function will be checking the impl of the syntax of elif stmt
+    '''
+    valid = True
+    reason = ''
+    if tokens[len(tokens)-1].token != ":":
+        valid = False
+        reason = 'Missing colon at the end in the used elif stmt.'
+    return [valid, reason]
+
+def check_ElseStmt(tokens):
+    '''
+    This function will be checking the impl of the syntax of else stmt
+    '''
+    valid = True
+    reason = ''
+    if tokens[len(tokens)-1].token != ":":
+        valid = False
+        reason = 'Missing colon at the end in the used else stmt.'
+    return [valid, reason]

--- a/Compiler/Parser/parser.py
+++ b/Compiler/Parser/parser.py
@@ -219,7 +219,6 @@ def statement_type(tokens) -> NodeTypes:
     else:
         return NodeTypes.EXPR
 
-
 """
 Parsing units
 """
@@ -244,6 +243,9 @@ def parse_ExprNode(tokens) -> ExprNode:
         if current_token.type == TokenType.IDENTIFIER:
             if i + 1 < len(tokens) and tokens[i + 1].token == "(":
                 node.tokens.append(Token(current_token.token + "(", TokenType.BLANK))
+                i += 1
+            elif i + 1 < len(tokens) and tokens[i + 1].token == ".":
+                Token(f'methodId("{current_token.token}","{tokens[i+2].token}")', TokenType.BLANK)
                 i += 1
             else:
                 node.tokens.append(

--- a/Compiler/Parser/parser.py
+++ b/Compiler/Parser/parser.py
@@ -475,19 +475,40 @@ def Compile(code: list) -> str:
                     )
 
             case NodeTypes.IF_STMT:
-                node = parse_IfStmt(line)
-                code_string += node.visit() + "\n"
-                scope_stack.append(Scope(indent_level + 1, NodeTypes.IF_STMT, 0))
+                if check_IfStmt(line)[0] != False:
+                    node = parse_IfStmt(line)
+                    code_string += node.visit() + "\n"
+                    scope_stack.append(Scope(indent_level + 1, NodeTypes.IF_STMT, 0))
+                else:
+                    print(
+                        SyntaxError(
+                            line_no, check_IfStmt(line)[1]
+                        )
+                    )
 
             case NodeTypes.ELIF_STMT:
-                node = parse_ElifStmt(line)
-                code_string += node.visit() + "\n"
-                scope_stack.append(Scope(indent_level + 1, NodeTypes.ELIF_STMT, 0))
+                if check_ElifStmt(line)[0] != False:
+                    node = parse_ElifStmt(line)
+                    code_string += node.visit() + "\n"
+                    scope_stack.append(Scope(indent_level + 1, NodeTypes.ELIF_STMT, 0))
+                else:
+                    print(
+                        SyntaxError(
+                            line_no, check_ElifStmt(line)[1]
+                        )
+                    )
 
             case NodeTypes.ELSE_STMT:
-                node = parse_ElseStmt()
-                code_string += node.visit() + "\n"
-                scope_stack.append(Scope(indent_level + 1, NodeTypes.ELSE_STMT, 0))
+                if check_ElseStmt(line)[0] != False:
+                    node = parse_ElseStmt()
+                    code_string += node.visit() + "\n"
+                    scope_stack.append(Scope(indent_level + 1, NodeTypes.ELSE_STMT, 0))
+                else:
+                    print(
+                        SyntaxError(
+                            line_no, check_ElseStmt(line)[1]
+                        )
+                    )
 
             case NodeTypes.WHILE_STMT:
                 node = parse_WhileStmt(line)

--- a/Compiler/Parser/parser.py
+++ b/Compiler/Parser/parser.py
@@ -245,7 +245,6 @@ def parse_ExprNode(tokens) -> ExprNode:
                 node.tokens.append(Token(current_token.token + "(", TokenType.BLANK))
                 i += 1
             elif i + 1 < len(tokens) and tokens[i + 1].token == ".":
-                print(4)
                 node.tokens.append(Token(f'methodId("{current_token.token}","{tokens[i+2].token}")', TokenType.BLANK))
                 i += 2
             else:

--- a/Compiler/Parser/parser.py
+++ b/Compiler/Parser/parser.py
@@ -245,8 +245,9 @@ def parse_ExprNode(tokens) -> ExprNode:
                 node.tokens.append(Token(current_token.token + "(", TokenType.BLANK))
                 i += 1
             elif i + 1 < len(tokens) and tokens[i + 1].token == ".":
-                Token(f'methodId("{current_token.token}","{tokens[i+2].token}")', TokenType.BLANK)
-                i += 1
+                print(4)
+                node.tokens.append(Token(f'methodId("{current_token.token}","{tokens[i+2].token}")', TokenType.BLANK))
+                i += 2
             else:
                 node.tokens.append(
                     Token(f'id("{current_token.token}")', TokenType.BLANK)

--- a/Compiler/Parser/parser.py
+++ b/Compiler/Parser/parser.py
@@ -180,6 +180,13 @@ def is_cimport_stmt(tokens) -> bool:
     else:
         return False
 
+def is_class(tokens) -> bool:
+    if tokens[0].token == "class":
+        return True
+    else:
+        return False
+
+
 def statement_type(tokens) -> NodeTypes:
     if is_var_decl(tokens):
         return NodeTypes.VAR_DECL
@@ -205,6 +212,8 @@ def statement_type(tokens) -> NodeTypes:
         return NodeTypes.IMPORT
     elif is_cimport_stmt(tokens):
         return NodeTypes.CIMPORT
+    elif is_class(tokens):
+        return NodeTypes.CLASS
     elif is_print_stmt(tokens):
         return NodeTypes.PRINT
     else:
@@ -319,6 +328,12 @@ def parse_WhileStmt(tokens) -> WhileStmtNode:
     node.condition = parse_ExprNode(tokens[1:])
     return node
 
+def parse_Class(tokens) -> ClassNode:
+    tokens.pop(len(tokens) - 1)
+
+    node = ClassNode()
+    return node
+
 
 def parse_FunDecl(tokens) -> FunDeclNode:
     # Remove unnecessary tokens
@@ -394,7 +409,7 @@ def Compile(code: list) -> str:
     code.append([Token("0", TokenType.VALUE)])
     # Resulting code
     code_string = ""
-
+    _class = False
     # Scope properties
     line_no = 1
     scope_stack = [Scope(0, NodeTypes.UNKNOWN_NODE, 0)]
@@ -459,6 +474,12 @@ def Compile(code: list) -> str:
                 node = parse_ForStmt(line)
                 code_string += node.visit() + "\n"
                 scope_stack.append(Scope(indent_level + 1, NodeTypes.FOR_STMT, 0))
+
+            case NodeTypes.CLASS:
+                node = parse_Class(line)
+                code_string += node.visit() + "\n"
+                _class = True
+                scope_stack.append(Scope(indent_level + 1, NodeTypes.CLASS, 0))
 
             case NodeTypes.FUN_DECL:
                 if check_FuncDecl(line)[0]:

--- a/Core/Builtin/codes.h
+++ b/Core/Builtin/codes.h
@@ -17,3 +17,4 @@ short names which looks elegant.
 #define main int main(int argc, char** argv){
 #define endmain return 0;}
 #define class_memvVar(cname,obj, name) dynamic_pointer_cast<cname>(id(obj).cus_type)->getMember(name);
+#define methodId(obj, classn, methodname) __classes__[classn].methods[methodname]

--- a/Core/Builtin/codes.h
+++ b/Core/Builtin/codes.h
@@ -18,3 +18,6 @@ short names which looks elegant.
 #define endmain return 0;}
 #define class_memvVar(cname,obj, name) dynamic_pointer_cast<cname>(id(obj).cus_type)->getMember(name);
 #define methodId(obj, methodname) __classes__[id(obj).__class__].methods[methodname]
+string object(Cell class_){
+    return class_.sval;
+}

--- a/Core/Builtin/codes.h
+++ b/Core/Builtin/codes.h
@@ -17,4 +17,4 @@ short names which looks elegant.
 #define main int main(int argc, char** argv){
 #define endmain return 0;}
 #define class_memvVar(cname,obj, name) dynamic_pointer_cast<cname>(id(obj).cus_type)->getMember(name);
-#define methodId(obj, classn, methodname) __classes__[classn].methods[methodname]
+#define methodId(obj, methodname) __classes__[id(obj).__class__].methods[methodname]

--- a/Core/Runtime/class.h
+++ b/Core/Runtime/class.h
@@ -1,0 +1,18 @@
+#if !defined(CLASSCSQ_H)
+#define CLASSCSQ_H
+
+#include <functional>
+#include <map>
+#include "memory.h"
+
+/*
+This in every case will be representing a class
+*/
+class Class {
+public:
+    string name;
+    map<string, function<void(vector<Cell>&)>> methods;
+    map<string, Cell&> methods;
+};
+
+#endif // CLASSCSQ_H

--- a/Core/Runtime/class.h
+++ b/Core/Runtime/class.h
@@ -11,7 +11,7 @@ This in every case will be representing a class
 class Class {
 public:
     string name;
-    map<string, function<void(Cell)>> methods;
+    map<string, function<Cell(Cell)>> methods;
     map<string, Cell> members;
 };
 

--- a/Core/Runtime/class.h
+++ b/Core/Runtime/class.h
@@ -11,8 +11,8 @@ This in every case will be representing a class
 class Class {
 public:
     string name;
-    map<string, function<void(vector<Cell>&)>> methods;
-    map<string, Cell&> methods;
+    map<string, function<void(Cell)>> methods;
+    map<string, Cell> members;
 };
 
 #endif // CLASSCSQ_H

--- a/Core/Runtime/core.h
+++ b/Core/Runtime/core.h
@@ -114,8 +114,11 @@ void allocateVar(string id_){
     SymTable[id_] = sym;
 }
 
-void allocateVar(string id_,string type, const CusType& val){
-    addCell(val);
+void allocateVar(string id_,string type){
+    Cell c;
+    c.type = CUSTYPE;
+    c.__class__ = type;
+    memory.push_back(c);
     Symbol sym;
     sym.var.name = id_;
     sym.type = VARIABLE;

--- a/Core/Runtime/core.h
+++ b/Core/Runtime/core.h
@@ -95,6 +95,18 @@ void allocateVar(string id_, string type, Cell c){
     SymTable[id_] = sym;
 }
 
+void allocateVar(string id_, string type, string c_){
+    Cell c;
+    c.type = CUSTYPE;
+    c.__class__ = c_;
+    memory.push_back(c);
+    Symbol sym;
+    sym.var.name = id_;
+    sym.type = VARIABLE;
+    sym.var.value_address = TopCellAddress();
+    SymTable[id_] = sym;
+}
+
 //This is only for the impl of OOP
 // template <typename T>
 // void allocateVar(const string& name, const string& type, T value) {

--- a/Core/Runtime/core.h
+++ b/Core/Runtime/core.h
@@ -15,6 +15,7 @@ int line_ = 1;
 #include "memory.h"
 #include "function.h"
 #include "eval.h"
+#include "class.h"
 #include <unordered_map>
 /*
 Possible types of symbol for the symbol table.
@@ -159,5 +160,7 @@ Cell id(string identifier, int index){
 }
 
 
+//Ultimate class storage where a table of every class will be made.
+map<string, Class> __classes__;
 
 #endif // RUNTIME_CORE_CSQ

--- a/Core/Runtime/memory.h
+++ b/Core/Runtime/memory.h
@@ -43,10 +43,6 @@ enum Type{
 };
 
 //Class to handle custom datatypes
-class CusType{
-    public:
-        virtual ~CusType() = default;
-};
 
 // Struct for a memory cell.
 struct Cell
@@ -57,7 +53,8 @@ struct Cell
     double fval;
     string sval;
     vector<Cell> array;
-    shared_ptr<CusType> cus_type;
+    //for custom type
+    string __class__;
 
 
     Cell operator+(const Cell& c) const {
@@ -268,9 +265,9 @@ void addCell(int val) {
     memory.emplace_back(cell);
 }
 
-void addCell(const CusType& object){
+void addCell(string class_){
     Cell cell;
-    cell.cus_type = make_shared<CusType>(object);
+    cell.__class__ = class_;
     cell.type = CUSTYPE;
     cell.u_count = 0;
     memory.emplace_back(cell);

--- a/Core/Runtime/memory.h
+++ b/Core/Runtime/memory.h
@@ -265,13 +265,13 @@ void addCell(int val) {
     memory.emplace_back(cell);
 }
 
-void addCell(string class_){
-    Cell cell;
-    cell.__class__ = class_;
-    cell.type = CUSTYPE;
-    cell.u_count = 0;
-    memory.emplace_back(cell);
-}
+// void addCell(string class_){
+//     Cell cell;
+//     cell.__class__ = class_;
+//     cell.type = CUSTYPE;
+//     cell.u_count = 0;
+//     memory.emplace_back(cell);
+// }
 
 void addCell(double val) {
     Cell cell;


### PR DESCRIPTION
I added certain new features for OOP and for now we can use it but only for calling methods from class.
Example:
```
class myclass:
 def say_hi:
  print 'Hi'

obj := object('myclass')
obj.say_hi(0)
```
* methods don't require param to be defined they are accessed as arg
* during calling any method we shall pass at least one argument for correct compilation and working.

And also solution for #232 