### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.csq linguist-language=Csquare


### PR DESCRIPTION
Add support for .csq files


The *.csq linguist-language=Csquare entry in a .gitattributes file is used to specify the programming language for files with the .csq extension, making it easier for tools like GitHub Linguist to correctly identify and highlight the code's syntax. This helps improve code readability and understanding within a Git repository.