### PR TITLE
Updated Cell overloadings for different types

### DIFF
--- a/Core/Builtin/basic.h
+++ b/Core/Builtin/basic.h
@@ -17,7 +17,7 @@ void print_(const Cell& cell) {
             std::cout <<  cell.floatVal;
             break;
         case Type::STRING:
-            std::cout << *cell.stringVal;
+            std::cout << "'" <<*cell.stringVal << "'";
             break;
         case Type::COMPOUND:
             std::cout << "[ ";

--- a/Core/Runtime/memory.h
+++ b/Core/Runtime/memory.h
@@ -142,8 +142,14 @@ struct Cell {
     inline Cell operator+(const Cell& other) const {
         if (type == Type::INT && other.type == Type::INT) {
             return Cell(intVal + other.intVal);
+        } else if(type == Type::STRING){
+            return Cell((*stringVal) + (*other.stringVal));
         } else if (type == Type::FLOAT && other.type == Type::FLOAT) {
             return Cell(floatVal + other.floatVal);
+        } else if(type == Type::FLOAT && other.type == Type::INT){
+            return Cell(floatVal + float(other.intVal));
+        } else if(type == Type::INT && other.type == Type::FLOAT){
+            return Cell(float(intVal) + (other.floatVal));
         }
         return Cell(); // Default case
     }
@@ -153,6 +159,10 @@ struct Cell {
             return Cell(intVal - other.intVal);
         } else if (type == Type::FLOAT && other.type == Type::FLOAT) {
             return Cell(floatVal - other.floatVal);
+        } else if(type == Type::FLOAT && other.type == Type::INT){
+            return Cell(floatVal - float(other.intVal));
+        } else if(type == Type::INT && other.type == Type::FLOAT){
+            return Cell(float(intVal) - (other.floatVal));
         }
         return Cell(); // Default case
     }
@@ -162,6 +172,10 @@ struct Cell {
             return Cell(intVal * other.intVal);
         } else if (type == Type::FLOAT && other.type == Type::FLOAT) {
             return Cell(floatVal * other.floatVal);
+        } else if(type == Type::FLOAT && other.type == Type::INT){
+            return Cell(floatVal * float(other.intVal));
+        } else if(type == Type::INT && other.type == Type::FLOAT){
+            return Cell(float(intVal) * (other.floatVal));
         }
         return Cell(); // Default case
     }
@@ -171,6 +185,10 @@ struct Cell {
             return Cell(intVal / other.intVal);
         } else if (type == Type::FLOAT && other.type == Type::FLOAT && other.floatVal != 0.0f) {
             return Cell(floatVal / other.floatVal);
+        } else if(type == Type::FLOAT && other.type == Type::INT){
+            return Cell(floatVal / float(other.intVal));
+        } else if(type == Type::INT && other.type == Type::FLOAT){
+            return Cell(float(intVal) / (other.floatVal));
         }
         return Cell(); // Default case
     }


### PR DESCRIPTION
Allowed operation between float and int 
```
a := 1.34
b := 2
print a + b
```
```
3.34
```